### PR TITLE
Fixed Column Names in enterprise_rma Table 

### DIFF
--- a/help/mbi/data-analyst/data-warehouse-mgr/enter-rma-table.md
+++ b/help/mbi/data-analyst/data-warehouse-mgr/enter-rma-table.md
@@ -17,11 +17,11 @@ Each row in the `enterprise_rma` table (often called `magento_rma` in Adobe Comm
 
 |**Column Name**|**Description**|
 |---|---|
-|`entity\_id`|Unique identifier for the table. Each `entity\_id` represents a return request.|
-|`date\_requested`|The date that the return was requested.|
+|`entity_id`|Unique identifier for the table. Each `entity_id` represents a return request.|
+|`date_requested`|The date that the return was requested.|
 |`status`|The status of the return. Values include 'received', 'pending', 'authorized', among others.|
-|`order\_id`|Foreign key associated with the `sales\_flat\_order` table.|
-|`customer\_id`|Foreign key associated with the `customer\_entity` table.|
+|`order_id`|Foreign key associated with the `sales_flat_order` table.|
+|`customer_id`|Foreign key associated with the `customer_entity` table.|
 
 {style="table-layout:auto"}
 
@@ -29,9 +29,9 @@ Each row in the `enterprise_rma` table (often called `magento_rma` in Adobe Comm
 
 |**Column Name**|**Description**|
 |---|---|
-|`Order's created\_at`|This is the date of the original order. This can be used to obtain the time between order and return request.|
+|`Order's created_at`|This is the date of the original order. This can be used to obtain the time between order and return request.|
 |`Customer's order number`|This is the customer's order number associated with the original order.|
-|`Seconds between order's created\_at and return's date\_requested`|The number of seconds from the order date to the return request.|
+|`Seconds between order's created_at and return's date_requested`|The number of seconds from the order date to the return request.|
 |`Return's total value`|This is the total monetary amount that is returned. This is the sum of each return item's individual return amount.|
 
 {style="table-layout:auto"}
@@ -40,7 +40,7 @@ Each row in the `enterprise_rma` table (often called `magento_rma` in Adobe Comm
 
 |**Metric Name**|**Description**|**Construction**|
 |---|---|---|
-|`Number of returns`|The number of returns requested.|`Operation` column: `entity id`<br>`Operation`: `Count`<br>`Timestamp` Column: `date requested`|
+|`Number of returns`|The number of returns requested.|`Operation` column: `entity_id`<br>`Operation`: `Count`<br>`Timestamp` Column: `date requested`|
 |`Total returned amount`|The total monetary amount returned.|`Operation `Column: `Return's total value`<br>`Operation`: Sum<br>`Timestamp` Column: date requested|
 |`Average returned amount`|The average monetary amount returned.|`Operation`` Column: Return's total value`<br>`Operation`: `Average`<br>`Timestamp` Column: `date requested`|
 |`Average time to return`|The average time from order to return.|`Operation` Column: Seconds between order's created at and return's date requested<br>`Operation`: `Average`<br>`Timestamp` Column: `date requested`|


### PR DESCRIPTION
The column names contained backward slashes. They were removed.
Also, one column had a space, replaced with an underscore.