### PR TITLE
[TEST] Add rake image_optim

### DIFF
--- a/_jekyll/Gemfile
+++ b/_jekyll/Gemfile
@@ -1,0 +1,14 @@
+# ADOBE CONFIDENTIAL
+# Copyright 2024 Adobe All Rights Reserved.
+# NOTICE:  All information contained herein is, and remains the property of Adobe and its suppliers, if any.
+# The intellectual and technical concepts contained herein are proprietary to Adobe and its suppliers and are protected by all applicable intellectual property laws, including trade secret and copyright laws.
+# Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained from Adobe.
+
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'image_optim'
+gem 'image_optim_pack'
+gem 'colorator'

--- a/_jekyll/Gemfile.lock
+++ b/_jekyll/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (1.1.0)
+    exifr (1.4.0)
+    fspath (3.1.2)
+    image_optim (0.31.3)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (>= 1.5, < 4)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+    image_optim_pack (0.11.1)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
+    image_size (3.4.0)
+    in_threads (1.6.0)
+    progress (3.6.0)
+    rake (13.2.1)
+
+PLATFORMS
+  arm64-darwin-22
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  colorator
+  image_optim
+  image_optim_pack
+  rake
+
+BUNDLED WITH
+   2.1.4

--- a/_jekyll/Rakefile
+++ b/_jekyll/Rakefile
@@ -1,0 +1,32 @@
+# ADOBE CONFIDENTIAL
+# Copyright 2024 Adobe All Rights Reserved.
+# NOTICE:  All information contained herein is, and remains the property of Adobe and its suppliers, if any.
+# The intellectual and technical concepts contained herein are proprietary to Adobe and its suppliers and are protected by all applicable intellectual property laws, including trade secret and copyright laws.
+# Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained from Adobe.
+
+# frozen_string_literal: true
+
+require 'yaml'
+require 'colorator'
+
+desc 'Optimize images in modified uncommitted files. For other images, use "path" such as "rake image_optim path=../path/to/dir/or/file".'
+task :image_optim do
+  puts
+  puts 'Checking images ...'.magenta
+  path = ENV['path']
+
+  unless path
+    puts 'Looking in uncommitted files ...'.blue
+    modified_files = `git ls-files --modified --others --exclude-standard`.split("\n")
+    deleted_files = `git ls-files --deleted`.split("\n")
+    image_files_to_check = (modified_files - deleted_files).select do |file|
+      File.extname(file) =~ /\.(png|jpg|jpeg|gif)/i
+    end
+
+    next puts 'No images to check.'.magenta if image_files_to_check.empty?
+
+    path = image_files_to_check.join(' ')
+  end
+
+  system "bundle exec image_optim --no-svgo --recursive #{path}"
+end


### PR DESCRIPTION
Add a toolkit to run image optimization.

## How to use

### Prerequisites

1. [Ruby](https://www.ruby-lang.org/en/)
    Check if you have Ruby: `ruby -v`
    If not, try https://github.com/rbenv/rbenv
1. [Bundler](https://bundler.io/). Needs Ruby.
   Check if you have Bundler: `bundle version`
   If not, run `gem install bundler`
1. Ruby gems. Needs Bundler.
   To install all required Ruby gems, change directory to the _jekyll directory and install dependencies listed in the Gemfile with Bundler: `cd _jekyll && bundle install`.

### Usage

Change directory to the _jekyll directory:

```
cd _jekyll
```

To run optimization for the images you've just added or modified but have not yet committed:

```
rake image_optim
```

To run optimization recursively for any other images using path, use path argument. Note, that you are running rake commands from the _jekyll directory, that's why your path should start from `../` to get to the root of the project:

```
rake image_optim path=../help/path/to/image/or/dir
```